### PR TITLE
Feature/step15

### DIFF
--- a/src/main/java/kr/hhplus/be/server/application/facade/PaymentFacade.java
+++ b/src/main/java/kr/hhplus/be/server/application/facade/PaymentFacade.java
@@ -8,15 +8,14 @@ import kr.hhplus.be.server.application.obj.PaymentCommand;
 import kr.hhplus.be.server.application.obj.PaymentResult;
 import kr.hhplus.be.server.domain.order.Order;
 import kr.hhplus.be.server.domain.order.OrderService;
-import kr.hhplus.be.server.domain.payment.Payment;
 import kr.hhplus.be.server.domain.payment.PaymentService;
-import kr.hhplus.be.server.domain.point.Point;
 import kr.hhplus.be.server.domain.point.PointService;
 import kr.hhplus.be.server.domain.reservation.Reservation;
 import kr.hhplus.be.server.domain.reservation.ReservationService;
 import kr.hhplus.be.server.domain.user.User;
 import kr.hhplus.be.server.domain.user.UserService;
 import kr.hhplus.be.server.infrastructure.lock.DistributedLock;
+import kr.hhplus.be.server.presentation.event.obj.PaymentCompleteEvent;
 import lombok.RequiredArgsConstructor;
 
 /**

--- a/src/main/java/kr/hhplus/be/server/application/facade/PaymentFacade.java
+++ b/src/main/java/kr/hhplus/be/server/application/facade/PaymentFacade.java
@@ -1,5 +1,6 @@
 package kr.hhplus.be.server.application.facade;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,42 +31,33 @@ public class PaymentFacade {
     private final OrderService orderService;
     private final PointService pointService;
     private final PaymentService paymentService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     @DistributedLock(key = "'payLock:' + #command.reservationId", waitTime = 5, leaseTime = 3)
     public PaymentResult pay(PaymentCommand command) {
-        // 사용자 확인
+        // 유저 및 소유권 검증
         User user = userService.getUser(command.getUserId());
-
-        // 예약 확인 및 소유권 검증 (락 없음)
         Reservation reservation = reservationService.getReservation(command.getReservationId());
         if (!reservation.getUserRefId().equals(user.getId())) {
-            throw new IllegalArgumentException("Reservation does not belong to user: " + command.getUserId());
+            throw new IllegalArgumentException("예약이 사용자에게 속하지 않습니다: " + command.getUserId());
         }
 
-        // 주문 확인, 비관적 락
         Order order = orderService.getOrder(reservation.getOrderRefId());
         if (!order.getUserRefId().equals(user.getId())) {
-            throw new IllegalArgumentException("Order does not belong to user: " + command.getUserId());
+            throw new IllegalArgumentException("주문이 사용자에게 속하지 않습니다: " + command.getUserId());
         }
 
-        // 포인트 사용, 비관적 락
-        Point point = pointService.usePoints(user.getId(), order.getTotalAmount());
+        // 결제 처리
+        paymentService.processPayment(user.getId(), order.getTotalAmount(), reservation.getReservationId(), order.getId());
 
-        // 예약 상태 완료, 비관적 락
-        reservationService.completeReservation(command.getReservationId());
-
-        // 결제 기록 생성, 비관적 락
-        Payment payment = paymentService.processPayment(user.getId(), order.getTotalAmount());
-
-        // 주문 업데이트
-        orderService.updatePaymentRefId(reservation.getOrderRefId(), payment.getId());
+        // 이벤트 발행
+        eventPublisher.publishEvent(new PaymentCompleteEvent(
+                paymentService.getPaymentId(), reservation.getReservationId(), user.getId()));
 
         PaymentResult response = new PaymentResult();
-        response.setPaymentStatus(payment.getPaymentStatus());
-        response.setRemainPoint(point.getRemainPoint().longValue());
-
+        response.setPaymentStatus("COMPLETED");
+        response.setRemainPoint(pointService.getPointBalance(user.getId()).longValue());
         return response;
     }
-
 }

--- a/src/main/java/kr/hhplus/be/server/application/facade/PaymentFacade.java
+++ b/src/main/java/kr/hhplus/be/server/application/facade/PaymentFacade.java
@@ -1,6 +1,5 @@
 package kr.hhplus.be.server.application.facade;
 
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,7 +14,6 @@ import kr.hhplus.be.server.domain.reservation.ReservationService;
 import kr.hhplus.be.server.domain.user.User;
 import kr.hhplus.be.server.domain.user.UserService;
 import kr.hhplus.be.server.infrastructure.lock.DistributedLock;
-import kr.hhplus.be.server.presentation.event.obj.PaymentCompleteEvent;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -30,7 +28,6 @@ public class PaymentFacade {
     private final OrderService orderService;
     private final PointService pointService;
     private final PaymentService paymentService;
-    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     @DistributedLock(key = "'payLock:' + #command.reservationId", waitTime = 5, leaseTime = 3)
@@ -49,10 +46,6 @@ public class PaymentFacade {
 
         // 결제 처리
         paymentService.processPayment(user.getId(), order.getTotalAmount(), reservation.getReservationId(), order.getId());
-
-        // 이벤트 발행
-        eventPublisher.publishEvent(new PaymentCompleteEvent(
-                paymentService.getPaymentId(), reservation.getReservationId(), user.getId()));
 
         PaymentResult response = new PaymentResult();
         response.setPaymentStatus("COMPLETED");

--- a/src/main/java/kr/hhplus/be/server/application/obj/ReserveCommand.java
+++ b/src/main/java/kr/hhplus/be/server/application/obj/ReserveCommand.java
@@ -8,7 +8,7 @@ import java.util.List;
 public class ReserveCommand {
     // 스케쥴과 좌석을 입력 받아야 함
     private Long scheduleId;
-    private List<Long> seatId;
+    private List<Long> seatIds;
     private String userId;
     private Integer price;
     private Long orderId;

--- a/src/main/java/kr/hhplus/be/server/application/period/PeriodType.java
+++ b/src/main/java/kr/hhplus/be/server/application/period/PeriodType.java
@@ -1,4 +1,4 @@
-package kr.hhplus.be.server.application.redis.obj;
+package kr.hhplus.be.server.application.period;
 
 import java.time.Instant;
 import java.time.LocalDate;

--- a/src/main/java/kr/hhplus/be/server/application/ranking/PopularityRankingService.java
+++ b/src/main/java/kr/hhplus/be/server/application/ranking/PopularityRankingService.java
@@ -1,4 +1,4 @@
-package kr.hhplus.be.server.application.redis;
+package kr.hhplus.be.server.application.ranking;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;

--- a/src/main/java/kr/hhplus/be/server/application/ranking/event/PopularityQueueConsumer.java
+++ b/src/main/java/kr/hhplus/be/server/application/ranking/event/PopularityQueueConsumer.java
@@ -1,4 +1,4 @@
-package kr.hhplus.be.server.application.redis;
+package kr.hhplus.be.server.application.ranking.event;
 
 import java.time.Instant;
 import java.util.List;
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import kr.hhplus.be.server.application.redis.obj.PeriodType;
+import kr.hhplus.be.server.application.period.PeriodType;
 import kr.hhplus.be.server.domain.schedule.Schedule;
 import kr.hhplus.be.server.domain.schedule.ScheduleService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/kr/hhplus/be/server/application/ranking/event/PopularityQueueProducer.java
+++ b/src/main/java/kr/hhplus/be/server/application/ranking/event/PopularityQueueProducer.java
@@ -1,4 +1,4 @@
-package kr.hhplus.be.server.application.redis;
+package kr.hhplus.be.server.application.ranking.event;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/src/main/java/kr/hhplus/be/server/domain/reservation/ReservationService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/reservation/ReservationService.java
@@ -1,16 +1,17 @@
 package kr.hhplus.be.server.domain.reservation;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import kr.hhplus.be.server.application.obj.ReserveCommand;
 import kr.hhplus.be.server.domain.reservationitem.ReservationItem;
 import kr.hhplus.be.server.domain.seatreservation.SeatReservation;
 import kr.hhplus.be.server.domain.seatreservation.SeatReservationRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -22,7 +23,7 @@ public class ReservationService {
     public Reservation createReservation(ReserveCommand command, Long userId) {
         // 예약 아이템 생성
         List<ReservationItem> items = new ArrayList<>();
-        for (Long seatId : command.getSeatId()) {
+        for (Long seatId : command.getSeatIds()) {
             ReservationItem item = new ReservationItem();
             item.setScheduleRefId(command.getScheduleId());
             item.setSeatRefId(seatId);
@@ -40,7 +41,7 @@ public class ReservationService {
         reservationRepository.save(reservation);
 
         // 좌석 예약 상태 업데이트
-        for (Long seatId : command.getSeatId()) {
+        for (Long seatId : command.getSeatIds()) {
             SeatReservation seatReservation = new SeatReservation();
             seatReservation.setSeatRefId(seatId);
             seatReservation.setReservationRefId(reservation.getReservationId());
@@ -58,7 +59,13 @@ public class ReservationService {
                 .orElseThrow(() -> new IllegalArgumentException("예약을 찾을 수 없습니다."));
         reservation.setReserveStatus(ReservationStatus.COMPLETED);
         reservationRepository.save(reservation);
+    }    
+    
+    public Reservation getReservation(Long reservationId) {
+    	return reservationRepository.findByReservationId(reservationId).orElseThrow();
     }
     
-    public Reservation getReservation(Long )
+    public void save(Reservation reservation) {
+    	reservationRepository.save(reservation);
+    }
 }

--- a/src/main/java/kr/hhplus/be/server/domain/reservation/ReservationService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/reservation/ReservationService.java
@@ -1,58 +1,64 @@
 package kr.hhplus.be.server.domain.reservation;
 
-import java.util.List;
-import java.util.UUID;
-
+import kr.hhplus.be.server.application.obj.ReserveCommand;
+import kr.hhplus.be.server.domain.reservationitem.ReservationItem;
+import kr.hhplus.be.server.domain.seatreservation.SeatReservation;
+import kr.hhplus.be.server.domain.seatreservation.SeatReservationRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import kr.hhplus.be.server.domain.reservationitem.ReservationItem;
-import lombok.RequiredArgsConstructor;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ReservationService {
     private final ReservationRepository reservationRepository;
-
-    @Transactional(readOnly = true)
-    public Reservation getReservation(Long reservationId) {
-        return reservationRepository.findByReservationId(reservationId)
-                .orElseThrow(() -> new IllegalArgumentException("Reservation not found: " + reservationId));
-    }
+    private final SeatReservationRepository seatReservationRepository;
 
     @Transactional
-    public Reservation completeReservation(Long reservationId) {
-        Reservation reservation = reservationRepository.findByReservationIdWithLock(reservationId)
-                .orElseThrow(() -> new IllegalArgumentException("Reservation not found: " + reservationId));
-
-        if (!reservation.isReservable()) {
-            throw new IllegalStateException("Reservation already completed: " + reservationId);
+    public Reservation createReservation(ReserveCommand command, Long userId) {
+        // 예약 아이템 생성
+        List<ReservationItem> items = new ArrayList<>();
+        for (Long seatId : command.getSeatId()) {
+            ReservationItem item = new ReservationItem();
+            item.setScheduleRefId(command.getScheduleId());
+            item.setSeatRefId(seatId);
+            item.setUnitPrice(command.getPrice());
+            items.add(item);
         }
 
-        reservation.reserve();
-        return reservationRepository.save(reservation);
+        // 예약 생성
+        Reservation reservation = new Reservation();
+        reservation.setUserRefId(userId);
+        reservation.setScheduleRefId(command.getScheduleId());
+        reservation.setOrderRefId(command.getOrderId());
+        reservation.setReservationItems(items);
+        reservation.setReserveStatus(ReservationStatus.READY);
+        reservationRepository.save(reservation);
+
+        // 좌석 예약 상태 업데이트
+        for (Long seatId : command.getSeatId()) {
+            SeatReservation seatReservation = new SeatReservation();
+            seatReservation.setSeatRefId(seatId);
+            seatReservation.setReservationRefId(reservation.getReservationId());
+            seatReservation.setReserved(true);
+            seatReservation.setReservedAt(Instant.now());
+            seatReservationRepository.save(seatReservation);
+        }
+
+        return reservation;
     }
 
     @Transactional
-    public Reservation createReservation(Long userRefId, Long scheduleRefId, Long orderRefId, List<ReservationItem> items) {
-        Reservation reservation = new Reservation();
-        reservation.setReservationId(generateUniqueReservationId());
-        reservation.setUserRefId(userRefId);
-        reservation.setScheduleRefId(scheduleRefId);
-        reservation.setOrderRefId(orderRefId);
-        reservation.setReserveStatus(ReservationStatus.READY);
-        reservation.setReservationItems(items);
-
-        return reservationRepository.save(reservation);
+    public void completeReservation(Long reservationId) {
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new IllegalArgumentException("예약을 찾을 수 없습니다."));
+        reservation.setReserveStatus(ReservationStatus.COMPLETED);
+        reservationRepository.save(reservation);
     }
     
-    public void save(Reservation obj) {
-    	reservationRepository.save(obj);
-    }
-
-    private Long generateUniqueReservationId() {
-        return Math.abs(UUID.randomUUID().getMostSignificantBits());
-    }
+    public Reservation getReservation(Long )
 }
-
-

--- a/src/main/java/kr/hhplus/be/server/presentation/event/PaymentEventListener.java
+++ b/src/main/java/kr/hhplus/be/server/presentation/event/PaymentEventListener.java
@@ -1,0 +1,29 @@
+package kr.hhplus.be.server.presentation.event;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import kr.hhplus.be.server.presentation.event.obj.PaymentCompleteEvent;
+
+import org.springframework.transaction.event.TransactionPhase;
+
+@Slf4j
+@Component
+public class PaymentEventListener {
+    // private final NotifyService notifyService; // 알림 서비스 (필요 시 추가)
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handlePaymentCompletedEvent(PaymentCompleteEvent event) {
+        try {
+            // 결제 완료 알림 발송
+            log.info("[이벤트] 결제 완료 - 결제 ID: {}, 예약 ID: {}, 사용자 ID: {}", 
+                    event.getPaymentId(), event.getReservationId(), event.getUserId());
+            // notifyService.sendPaymentNotification(event.getPaymentId(), event.getUserId());
+        } catch (Exception e) {
+            log.warn("[!] 결제 완료 알림 발송 실패: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/presentation/event/PaymentEventListener.java
+++ b/src/main/java/kr/hhplus/be/server/presentation/event/PaymentEventListener.java
@@ -1,27 +1,28 @@
 package kr.hhplus.be.server.presentation.event;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import kr.hhplus.be.server.domain.order.OrderService;
 import kr.hhplus.be.server.presentation.event.obj.PaymentCompleteEvent;
 
 import org.springframework.transaction.event.TransactionPhase;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class PaymentEventListener {
-    // private final NotifyService notifyService; // 알림 서비스 (필요 시 추가)
+    private final OrderService orderService;
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePaymentCompletedEvent(PaymentCompleteEvent event) {
         try {
-            // 결제 완료 알림 발송
-            log.info("[이벤트] 결제 완료 - 결제 ID: {}, 예약 ID: {}, 사용자 ID: {}", 
-                    event.getPaymentId(), event.getReservationId(), event.getUserId());
-            // notifyService.sendPaymentNotification(event.getPaymentId(), event.getUserId());
+        	// 주문 상태 업데이트
+            orderService.updatePaymentRefId(event.getOrderId(), event.getPaymentId());
         } catch (Exception e) {
             log.warn("[!] 결제 완료 알림 발송 실패: {}", e.getMessage());
         }

--- a/src/main/java/kr/hhplus/be/server/presentation/event/PopularityQueueConsumer.java
+++ b/src/main/java/kr/hhplus/be/server/presentation/event/PopularityQueueConsumer.java
@@ -1,4 +1,4 @@
-package kr.hhplus.be.server.application.ranking.event;
+package kr.hhplus.be.server.presentation.event;
 
 import java.time.Instant;
 import java.util.List;
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import kr.hhplus.be.server.application.period.PeriodType;
+import kr.hhplus.be.server.application.ranking.event.PopularityQueueProducer;
+import kr.hhplus.be.server.application.ranking.event.PopularityQueueProducer.PopularityMessage;
 import kr.hhplus.be.server.domain.schedule.Schedule;
 import kr.hhplus.be.server.domain.schedule.ScheduleService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/kr/hhplus/be/server/presentation/event/ReservationEventListener.java
+++ b/src/main/java/kr/hhplus/be/server/presentation/event/ReservationEventListener.java
@@ -1,58 +1,28 @@
 package kr.hhplus.be.server.presentation.event;
 
-import kr.hhplus.be.server.domain.seatreservation.SeatReservationRepository;
-import kr.hhplus.be.server.infrastructure.queue.obj.ReservationEvent;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import kr.hhplus.be.server.domain.reservation.ReservationService;
 import kr.hhplus.be.server.presentation.event.obj.SeatReservedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionalEventListener;
-import org.springframework.transaction.event.TransactionPhase;
-
-import java.time.Instant;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ReservationEventListener {
-    private final SeatReservationRepository seatReservationRepository;
-    // private final NotifyService notifyService; // 알림 서비스 (필요 시 추가)
-    // private final PerformanceService performanceService; // 인기도 업데이트용 (필요 시 추가)
+    private final ReservationService reservationService;
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleSeatReservedEvent(SeatReservedEvent event) {
         try {
-            // 좌석 예약 알림 발송
-            log.info("[이벤트] 좌석 예약 완료 - 예약 ID: {}, 스케줄 ID: {}, 좌석 IDs: {}", 
-                    event.getReservationId(), event.getScheduleId(), event.getSeatIds());
-            // notifyService.sendReservationNotification(event.getReservationId(), event.getSeatIds());
+            this.reservationService.completeReservation(event.getReservationId());
         } catch (Exception e) {
             log.warn("[!] 좌석 예약 알림 발송 실패: {}", e.getMessage());
-        }
-
-        // 좌석 만료 처리
-        seatReservationRepository.findByReservationId(event.getReservationId())
-                .stream()
-                .filter(seat -> seat.getExpiresAt().isBefore(Instant.now()))
-                .forEach(seat -> {
-                    seat.setReserved(false);
-                    seatReservationRepository.save(seat);
-                    log.info("[이벤트] 좌석 예약 만료 - 좌석 ID: {}", seat.getSeatRefId());
-                });
-    }
-
-    @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleReservationEvent(ReservationEvent event) {
-        try {
-            // 인기도 업데이트
-            log.info("[이벤트] 인기도 업데이트 - 공연 ID: {}, 스케줄 ID: {}, 예약된 좌석: {}/{}", 
-                    event.getPerformanceId(), event.getScheduleId(), event.getReservedSeats(), event.getTotalSeats());
-            // performanceService.updatePopularity(event.getPerformanceId(), event.getReservedSeats());
-        } catch (Exception e) {
-            log.warn("[!] 인기도 업데이트 실패: {}", e.getMessage());
         }
     }
 }

--- a/src/main/java/kr/hhplus/be/server/presentation/event/ReservationEventListener.java
+++ b/src/main/java/kr/hhplus/be/server/presentation/event/ReservationEventListener.java
@@ -1,0 +1,58 @@
+package kr.hhplus.be.server.presentation.event;
+
+import kr.hhplus.be.server.domain.seatreservation.SeatReservationRepository;
+import kr.hhplus.be.server.infrastructure.queue.obj.ReservationEvent;
+import kr.hhplus.be.server.presentation.event.obj.SeatReservedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.event.TransactionPhase;
+
+import java.time.Instant;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReservationEventListener {
+    private final SeatReservationRepository seatReservationRepository;
+    // private final NotifyService notifyService; // 알림 서비스 (필요 시 추가)
+    // private final PerformanceService performanceService; // 인기도 업데이트용 (필요 시 추가)
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleSeatReservedEvent(SeatReservedEvent event) {
+        try {
+            // 좌석 예약 알림 발송
+            log.info("[이벤트] 좌석 예약 완료 - 예약 ID: {}, 스케줄 ID: {}, 좌석 IDs: {}", 
+                    event.getReservationId(), event.getScheduleId(), event.getSeatIds());
+            // notifyService.sendReservationNotification(event.getReservationId(), event.getSeatIds());
+        } catch (Exception e) {
+            log.warn("[!] 좌석 예약 알림 발송 실패: {}", e.getMessage());
+        }
+
+        // 좌석 만료 처리
+        seatReservationRepository.findByReservationId(event.getReservationId())
+                .stream()
+                .filter(seat -> seat.getExpiresAt().isBefore(Instant.now()))
+                .forEach(seat -> {
+                    seat.setReserved(false);
+                    seatReservationRepository.save(seat);
+                    log.info("[이벤트] 좌석 예약 만료 - 좌석 ID: {}", seat.getSeatRefId());
+                });
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleReservationEvent(ReservationEvent event) {
+        try {
+            // 인기도 업데이트
+            log.info("[이벤트] 인기도 업데이트 - 공연 ID: {}, 스케줄 ID: {}, 예약된 좌석: {}/{}", 
+                    event.getPerformanceId(), event.getScheduleId(), event.getReservedSeats(), event.getTotalSeats());
+            // performanceService.updatePopularity(event.getPerformanceId(), event.getReservedSeats());
+        } catch (Exception e) {
+            log.warn("[!] 인기도 업데이트 실패: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/presentation/event/obj/PaymentCompleteEvent.java
+++ b/src/main/java/kr/hhplus/be/server/presentation/event/obj/PaymentCompleteEvent.java
@@ -1,0 +1,12 @@
+package kr.hhplus.be.server.presentation.event.obj;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class PaymentCompleteEvent {
+	private Long paymentId;
+	private Long reservationId;
+	private Long userId;
+}

--- a/src/main/java/kr/hhplus/be/server/presentation/event/obj/PaymentCompleteEvent.java
+++ b/src/main/java/kr/hhplus/be/server/presentation/event/obj/PaymentCompleteEvent.java
@@ -9,4 +9,5 @@ public class PaymentCompleteEvent {
 	private Long paymentId;
 	private Long reservationId;
 	private Long userId;
+	private Long orderId;
 }

--- a/src/main/java/kr/hhplus/be/server/presentation/event/obj/SeatReservedEvent.java
+++ b/src/main/java/kr/hhplus/be/server/presentation/event/obj/SeatReservedEvent.java
@@ -1,0 +1,14 @@
+package kr.hhplus.be.server.presentation.event.obj;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class SeatReservedEvent{
+	private Long reservationId;
+	private Long scheduleId;
+	private List<Long> seatIds;
+}

--- a/src/test/java/kr/hhplus/be/server/facade/PaymentFacadeDistributedLockIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/facade/PaymentFacadeDistributedLockIntegrationTest.java
@@ -28,8 +28,6 @@ import kr.hhplus.be.server.application.obj.PaymentCommand;
 import kr.hhplus.be.server.application.obj.PaymentResult;
 import kr.hhplus.be.server.domain.order.Order;
 import kr.hhplus.be.server.domain.order.OrderService;
-import kr.hhplus.be.server.domain.payment.PaymentRepository;
-import kr.hhplus.be.server.domain.payment.PaymentService;
 import kr.hhplus.be.server.domain.point.Point;
 import kr.hhplus.be.server.domain.point.PointService;
 import kr.hhplus.be.server.domain.reservation.Reservation;

--- a/src/test/java/kr/hhplus/be/server/facade/PaymentFacadeUnitTest.java
+++ b/src/test/java/kr/hhplus/be/server/facade/PaymentFacadeUnitTest.java
@@ -92,7 +92,6 @@ public class PaymentFacadeUnitTest {
         when(orderService.getOrder(reservation.getOrderRefId())).thenReturn(order);
         when(pointService.usePoints(user.getId(), order.getTotalAmount())).thenReturn(point);
         when(reservationService.completeReservation(reservationId)).thenReturn(reservation);
-        when(paymentService.processPayment(user.getId(), order.getTotalAmount())).thenReturn(payment);
         when(orderService.updatePaymentRefId(order.getId(), payment.getId())).thenReturn(order);
 
         // when
@@ -108,7 +107,6 @@ public class PaymentFacadeUnitTest {
         verify(orderService).getOrder(reservation.getOrderRefId());
         verify(pointService).usePoints(user.getId(), order.getTotalAmount());
         verify(reservationService).completeReservation(reservationId);
-        verify(paymentService).processPayment(user.getId(), order.getTotalAmount());
         verify(orderService).updatePaymentRefId(order.getId(), payment.getId());
         verifyNoMoreInteractions(userService, reservationService, orderService, pointService, paymentService, reservationItemService);
     }

--- a/src/test/java/kr/hhplus/be/server/facade/PaymentFacadeUnitTest.java
+++ b/src/test/java/kr/hhplus/be/server/facade/PaymentFacadeUnitTest.java
@@ -91,7 +91,6 @@ public class PaymentFacadeUnitTest {
         when(reservationService.getReservation(reservationId)).thenReturn(reservation);
         when(orderService.getOrder(reservation.getOrderRefId())).thenReturn(order);
         when(pointService.usePoints(user.getId(), order.getTotalAmount())).thenReturn(point);
-        when(reservationService.completeReservation(reservationId)).thenReturn(reservation);
         when(orderService.updatePaymentRefId(order.getId(), payment.getId())).thenReturn(order);
 
         // when

--- a/src/test/java/kr/hhplus/be/server/facade/ReservationFacadeDistributedLockIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/facade/ReservationFacadeDistributedLockIntegrationTest.java
@@ -56,7 +56,7 @@ class ReservationFacadeDistributedLockIntegrationTest {
 
     @Autowired
     private ReservationFacade reservationFacade;
-
+	
     @Autowired
     private UserService userService;
 
@@ -133,7 +133,7 @@ class ReservationFacadeDistributedLockIntegrationTest {
         command.setUserId(testUser.getUserId());
         command.setScheduleId(testSchedule.getScheduleId());
         command.setOrderId(testOrderId);
-        command.setSeatId(Arrays.asList(1L, 2L));
+        command.setSeatIds(Arrays.asList(1L, 2L));
         command.setPrice(100);
 
         // When
@@ -164,7 +164,7 @@ class ReservationFacadeDistributedLockIntegrationTest {
         command.setUserId(testUser.getUserId());
         command.setScheduleId(999L); // 존재하지 않는 스케줄
         command.setOrderId(testOrderId);
-        command.setSeatId(Arrays.asList(1L, 2L));
+        command.setSeatIds(Arrays.asList(1L, 2L));
         command.setPrice(100);
 
         // When & Then
@@ -187,7 +187,7 @@ class ReservationFacadeDistributedLockIntegrationTest {
         command.setUserId(testUser.getUserId());
         command.setScheduleId(testSchedule.getScheduleId());
         command.setOrderId(testOrderId);
-        command.setSeatId(Arrays.asList(1L, 2L));
+        command.setSeatIds(Arrays.asList(1L, 2L));
         command.setPrice(100);
 
         // When & Then
@@ -203,7 +203,7 @@ class ReservationFacadeDistributedLockIntegrationTest {
         command.setUserId("invalidUser"); // 존재하지 않는 사용자
         command.setScheduleId(testSchedule.getScheduleId());
         command.setOrderId(testOrderId);
-        command.setSeatId(Arrays.asList(1L, 2L));
+        command.setSeatIds(Arrays.asList(1L, 2L));
         command.setPrice(100);
 
         // When & Then
@@ -219,7 +219,7 @@ class ReservationFacadeDistributedLockIntegrationTest {
         command.setUserId(testUser.getUserId());
         command.setScheduleId(testSchedule.getScheduleId());
         command.setOrderId(testOrderId);
-        command.setSeatId(Arrays.asList(1L, 2L));
+        command.setSeatIds(Arrays.asList(1L, 2L));
         command.setPrice(100);
 
         ExecutorService executorService = Executors.newFixedThreadPool(5);


### PR DESCRIPTION
### **커밋 링크**
랭킹 이벤트 리팩토링 : 22fee9ad595f6c6f903c9543c57974bcef7fd65e
이벤트 기반으로 변경 : 66709bb4ff978df38fcd552637a5ffedce7d5853...20bdb4b978e8aa367412ada2e71996f1e3c15763

---
### **리뷰 포인트(질문)**
- 파사드에 트랜잭션을 건 경우에는 이벤트 구조로 어떻게 분리하여야 가장 옳을지 모르겠습니다. 
아래는 기존 코드입니다.
```
public class 예약파사드 {
    @Transactional
    public Reservation reserve() {
        유저 검증()
        좌석 확인()
        예약 상태 업데이트()
        예약 완료()
        인기도 업데이트() 
    }
}
```
위 구조에서 
```
public class 예약파사드 {
    @Transactional
    public Reservation reserve() {
        유저 검증()
        좌석 확인()
        예약 이벤트 발행()
        인기도 업데이트 이벤트 발행() 
    }
}
```
이렇게 바꾸었습니다. 맞게 작성한것일까요?
- 엄청나게 많은 서비스가 하나의 로직에 참여하고 있다면, 핵심 로직을 제외한 나머지를 "전부" 이벤트로 변경하는게 맞을까요?

---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->
제출하려는 끈기는 계속 잘 유지되고 있는 것 같습니다.

### Problem
<!--개선이 필요한 점-->
이벤트 구조로 개선하니, 보이지 않던 문제점들이 많이 보이고 있습니다.
구조 자체를 전체적으로 리팩토링 할 필요가 있습니다...

### Try
<!-- 새롭게 시도할 점 -->
이미 개발해둔 내용이 제대로 작동하지 않고있어서 아예 새롭게 다시 프로젝트를 구성해야할 것으로 보입니다.